### PR TITLE
fix: Gamepad not detected due to window handle definition error

### DIFF
--- a/sources/engine/Stride.Input/Windows/GameControllerDirectInput.cs
+++ b/sources/engine/Stride.Input/Windows/GameControllerDirectInput.cs
@@ -37,7 +37,10 @@ namespace Stride.Input
             Id = instance.InstanceGuid;
             ProductId = instance.ProductGuid;
             joystick = new DirectInputJoystick(directInput, instance.InstanceGuid);
-            joystick.SetCooperativeLevel(IntPtr.Zero, CooperativeLevel.NonExclusive | CooperativeLevel.Foreground);
+            var descriptor = RawInput.Win32.GetForegroundWindow();
+            
+            if (descriptor != IntPtr.Zero)
+                joystick.SetCooperativeLevel(descriptor, CooperativeLevel.NonExclusive | CooperativeLevel.Background);
             var objects = joystick.GetObjects();
 
             int sliderCount = 0;

--- a/sources/engine/Stride.Input/Windows/GameControllerDirectInput.cs
+++ b/sources/engine/Stride.Input/Windows/GameControllerDirectInput.cs
@@ -38,9 +38,7 @@ namespace Stride.Input
             ProductId = instance.ProductGuid;
             joystick = new DirectInputJoystick(directInput, instance.InstanceGuid);
             var descriptor = RawInput.Win32.GetForegroundWindow();
-            
-            if (descriptor != IntPtr.Zero)
-                joystick.SetCooperativeLevel(descriptor, CooperativeLevel.NonExclusive | CooperativeLevel.Background);
+            joystick.SetCooperativeLevel(descriptor, CooperativeLevel.NonExclusive | CooperativeLevel.Background);
             var objects = joystick.GetObjects();
 
             int sliderCount = 0;

--- a/sources/engine/Stride.Input/Windows/RawInput/Win32.cs
+++ b/sources/engine/Stride.Input/Windows/RawInput/Win32.cs
@@ -16,6 +16,9 @@ namespace Stride.Input.RawInput
 
         [DllImport("user32.dll")]
         public static extern void ClipCursor(IntPtr rect);
+
+        [DllImport("user32.dll")] 
+        public static extern IntPtr GetForegroundWindow();
     }
 }
 #endif


### PR DESCRIPTION
# PR Details
When connecting a Logitech RumblePad II gamepad, DirectInput returns an error related to an invalid window identifier

## Related Issue

[#1791](https://github.com/stride3d/stride/issues/1791)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**
