### PR TITLE
Update Silk.Net from 2.22.0 to 2.23.0

### DIFF
--- a/sources/Directory.Packages.props
+++ b/sources/Directory.Packages.props
@@ -25,16 +25,16 @@
     <PackageVersion Include="SharpDX.DirectInput" Version="4.2.0" />
     <PackageVersion Include="SharpDX.RawInput" Version="4.2.0" />
     <PackageVersion Include="SharpDX.XInput" Version="4.2.0" />
-    <PackageVersion Include="Silk.NET.Direct3D11" Version="2.22.0" />
-    <PackageVersion Include="Silk.NET.Direct3D12" Version="2.22.0" />
-    <PackageVersion Include="Silk.NET.Direct3D.Compilers" Version="2.22.0" />
-    <PackageVersion Include="Silk.NET.OpenGL" Version="2.22.0" />
-    <PackageVersion Include="Silk.NET.OpenGLES" Version="2.22.0" />
-    <PackageVersion Include="Silk.NET.OpenGLES.Extensions.EXT" Version="2.22.0" />
-    <PackageVersion Include="Silk.NET.OpenXR" Version="2.22.0" />
-    <PackageVersion Include="Silk.NET.OpenXR.Extensions.FB" Version="2.22.0" />
-    <PackageVersion Include="Silk.NET.Sdl" Version="2.22.0" />
-    <PackageVersion Include="Silk.NET.Windowing.Sdl" Version="2.22.0" />
+    <PackageVersion Include="Silk.NET.Direct3D11" Version="2.23.0" />
+    <PackageVersion Include="Silk.NET.Direct3D12" Version="2.23.0" />
+    <PackageVersion Include="Silk.NET.Direct3D.Compilers" Version="2.23.0" />
+    <PackageVersion Include="Silk.NET.OpenGL" Version="2.23.0" />
+    <PackageVersion Include="Silk.NET.OpenGLES" Version="2.23.0" />
+    <PackageVersion Include="Silk.NET.OpenGLES.Extensions.EXT" Version="2.23.0" />
+    <PackageVersion Include="Silk.NET.OpenXR" Version="2.23.0" />
+    <PackageVersion Include="Silk.NET.OpenXR.Extensions.FB" Version="2.23.0" />
+    <PackageVersion Include="Silk.NET.Sdl" Version="2.23.0" />
+    <PackageVersion Include="Silk.NET.Windowing.Sdl" Version="2.23.0" />
     <PackageVersion Include="Stride.SharpFont" Version="1.0.1" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.1" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
@@ -66,7 +66,7 @@
     <PackageVersion Include="NuGet.PackageManagement" Version="7.0.0" />
     <PackageVersion Include="NuGet.Protocol" Version="7.0.0" />
     <PackageVersion Include="NuGet.Resolver" Version="7.0.0" />
-    <PackageVersion Include="Silk.NET.Assimp" Version="2.22.0" />
+    <PackageVersion Include="Silk.NET.Assimp" Version="2.23.0" />
     <PackageVersion Include="Stride.GNU.Getopt" Version="2.0.0" />
     <PackageVersion Include="Stride.GNU.Gettext" Version="2.0.0" />
     <PackageVersion Include="Stride.Mono.TextTemplating" Version="2.1.0-preview-0009-g0d0b6db3ca" />


### PR DESCRIPTION
# PR Details

Updates Silk.Net packages to latest version

**Updates summary:** https://github.com/dotnet/Silk.NET/releases/tag/v2.23.0  
**Upstream PR:** https://github.com/dotnet/Silk.NET/pull/2489

###  The following packages are updated:

- Silk.NET.Direct3D11
- Silk.NET.Direct3D12
- Silk.NET.Direct3D.Compilers
- Silk.NET.OpenGL
- Silk.NET.OpenGLES
- Silk.NET.OpenGLES.Extensions.EXT
- Silk.NET.OpenXR
- Silk.NET.OpenXR.Extensions.FB
- Silk.NET.Sdl
- Silk.NET.Windowing.Sdl
- Silk.NET.Assimp

### Notable changes in Silk.NET v2.23.0 relevant to Stride:

- Fixes bone twisting artifacts during animation caused by incorrect handling of quaternion interpolation / transform propagation in Silk.NET.Assimp

## Related Issue

N/A

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] **I have built and run the editor to try this change out.**